### PR TITLE
Ship to es5

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "module": "es6",
-        "target": "esnext",
+        "target": "es5",
         "declaration": true,
         "allowJs": false,
         "noImplicitAny": false,


### PR DESCRIPTION
## Problem
Tries to fix #1 wherein projects using Parcel get this error:

```
Uncaught TypeError: Class constructor Container cannot be invoked without 'new'
```

## Overview
This makes it so that our build transpiles ES6 classes to ES5 function classes.

Adds roughly 1-2 LOC to the build.

-----

Here's an [example repository](https://github.com/srph/unstated-class-constructor-bug-fix) that shows this works.