### PR TITLE
Simplify implementation with design for react async

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 This project adheres to Semantic Versioning.
 
+## 3.0.0
+
+- This module is now designed for the upcoming concurrent mode of React. Avoid usin this version for a non concurrent mode React application.
+- `setState` is now sync
+
 ## 2.0.3
 
 - Fix second argument of `useUnstated` to skip update

--- a/__tests__/unstated.tsx
+++ b/__tests__/unstated.tsx
@@ -111,13 +111,14 @@ test('should incresase/decrease state counter in container using useUnstated', a
 
 test('should remove subscriber listeners if component is unmounted', () => {
     const counter = new CounterContainer();
-    const tree = renderer.create(
-        <Provider inject={[counter]}>
-            <Counter />
-        </Provider>
-    );
-    const testInstance = tree.root.findByType(Subscribe)._fiber.stateNode;
-
+    let tree;
+    renderer.act(() => {
+        tree = renderer.create(
+            <Provider inject={[counter]}>
+                <Counter />
+            </Provider>
+        );
+    });
     expect(counter.listeners.size).toBe(1);
 
     tree.unmount();
@@ -127,15 +128,20 @@ test('should remove subscriber listeners if component is unmounted', () => {
 
 test('should remove subscriber listeners if component is unmounted with useUnstated', () => {
     const counter = new CounterContainer();
-    const tree = renderer.create(
-        <Provider inject={[counter]}>
-            <CounterWithUse />
-        </Provider>
-    );
+    let tree;
+    renderer.act(() => {
+        tree = renderer.create(
+            <Provider inject={[counter]}>
+                <CounterWithUse />
+            </Provider>
+        );
+    });
     expect(() => tree.root.findByType(CounterWithUse)).not.toThrow();
     expect(counter.listeners.size).toBe(1);
 
-    counter.increment();
+    renderer.act(() => {
+        counter.increment();
+    });
 
     tree.unmount();
     expect(() => tree.root.findByType(CounterWithUse)).toThrowError(

--- a/package.json
+++ b/package.json
@@ -18,10 +18,8 @@
     "devDependencies": {
         "@types/jest": "^24.0.11",
         "@types/react": "^16.8.8",
-        "@types/react-dom": "^16.8.3",
         "jest": "^24.5.0",
         "react": "^16.8.4",
-        "react-dom": "^16.8.4",
         "react-test-renderer": "^16.8.4",
         "rollup": "^1.7.0",
         "rollup-plugin-typescript2": "^0.20.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gitbook/unstated",
-    "version": "2.0.3",
+    "version": "3.0.0-pre.1",
     "description": "Simple state library for react application",
     "main": "dist/unstated.js",
     "module": "dist/unstated.es.js",

--- a/src/container.ts
+++ b/src/container.ts
@@ -1,11 +1,3 @@
-import { unstable_batchedUpdates } from 'react-dom';
-
-const batchUpdates =
-    unstable_batchedUpdates ||
-    ((callback: () => void) => {
-        callback();
-    });
-
 type Listener = () => void;
 
 // Type interface for the constructor of a container
@@ -17,32 +9,18 @@ class Container<State = {}> {
     public listeners: Set<Listener> = new Set();
 
     public setState(
-        updater: Partial<State> | ((prevState: State) => Partial<State> | null),
-        callback?: () => void
-    ): Promise<void> {
-        const promise = new Promise(resolve => {
-            const nextState =
-                typeof updater === 'function' ? updater(this.state) : updater;
+        updater: Partial<State> | ((prevState: State) => Partial<State> | null)
+    ) {
+        const nextState =
+            typeof updater === 'function' ? updater(this.state) : updater;
 
-            if (nextState == null) {
-                resolve();
-                return;
-            }
+        if (nextState == null) {
+            return;
+        }
 
-            this.state = Object.assign({}, this.state, nextState);
-
-            batchUpdates(() => {
-                this.listeners.forEach(listener => {
-                    listener();
-                });
-                resolve();
-            });
-        });
-
-        return promise.then(() => {
-            if (callback) {
-                callback();
-            }
+        this.state = Object.assign({}, this.state, nextState);
+        this.listeners.forEach(listener => {
+            listener();
         });
     }
 

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -1,10 +1,4 @@
-import {
-    useContext,
-    useEffect,
-    useMemo,
-    useRef,
-    useState
-} from 'react';
+import { useContext, useEffect, useMemo, useRef, useState } from 'react';
 import { Container, ContainerConstructor } from './container';
 import { StateContext } from './provider';
 import { shallowEqual } from './shallowEqual';
@@ -55,7 +49,7 @@ export function useUnstated<C extends Container, UpdateCriteria = []>(
 ): C {
     const instance = useContainer(ContainerItem);
     const setUpdates = useState(0)[1];
-    const latestStateRef = useRef<object | null>(null)
+    const latestStateRef = useRef<object | null>(null);
     const updateCriteriaRef = useRef<UpdateCriteria | null>(null);
     const unmountedRef = useRef(false);
 
@@ -103,5 +97,5 @@ export function useUnstated<C extends Container, UpdateCriteria = []>(
     }, [instance]);
 
     latestStateRef.current = instance.state;
-    return instance
+    return instance;
 }

--- a/src/shallowEqual.ts
+++ b/src/shallowEqual.ts
@@ -29,11 +29,8 @@ export function shallowEqual(objA: any, objB: any): boolean {
         return false;
     }
 
-    for (let i = 0; i < keysA.length; i += 1) {
-        if (
-            !hasOwn.call(objB, keysA[i]) ||
-            !is(objA[keysA[i]], objB[keysA[i]])
-        ) {
+    for (const keyA in keysA) {
+        if (!hasOwn.call(objB, keyA) || !is(objA[keyA], objB[keyA])) {
             return false;
         }
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -341,14 +341,7 @@
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.0.tgz#4c48fed958d6dcf9487195a0ef6456d5f6e0163a"
   integrity sha512-eItQyV43bj4rR3JPV0Skpl1SncRCdziTEK9/v8VwXmV6d/qOUO8/EuWeHBbCZcsfSHfzI5UyMJLCSXtxxznyZg==
 
-"@types/react-dom@^16.8.3":
-  version "16.8.3"
-  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-16.8.3.tgz#6131b7b6158bc7ed1925a3374b88b7c00481f0cb"
-  integrity sha512-HF5hD5YR3z9Mn6kXcW1VKe4AQ04ZlZj1EdLBae61hzQ3eEWWxMgNLUbIxeZp40BnSxqY1eAYLsH9QopQcxzScA==
-  dependencies:
-    "@types/react" "*"
-
-"@types/react@*", "@types/react@^16.8.8":
+"@types/react@^16.8.8":
   version "16.8.8"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-16.8.8.tgz#4b60a469fd2469f7aa6eaa0f8cfbc51f6d76e662"
   integrity sha512-xwEvyet96u7WnB96kqY0yY7qxx/pEpU51QeACkKFtrgjjXITQn0oO1iwPEraXVgh10ZFPix7gs1R4OJXF7P5sg==
@@ -2748,16 +2741,6 @@ qs@~6.5.2:
   version "6.5.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
   integrity sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
-
-react-dom@^16.8.4:
-  version "16.8.4"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.8.4.tgz#1061a8e01a2b3b0c8160037441c3bf00a0e3bc48"
-  integrity sha512-Ob2wK7XG2tUDt7ps7LtLzGYYB6DXMCLj0G5fO6WeEICtT4/HdpOi7W/xLzZnR6RCG1tYza60nMdqtxzA8FaPJQ==
-  dependencies:
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-    prop-types "^15.6.2"
-    scheduler "^0.13.4"
 
 react-is@^16.8.1, react-is@^16.8.4:
   version "16.8.4"


### PR DESCRIPTION
This PR simplifies the unstated implementation to work with [async rendering of react](https://reactjs.org/docs/concurrent-mode-adoption.html#feature-comparison). 

It fixes potential warning when using unstated with react async when setState is done on an unmounted component (it happens when the component is being rendered on a branch then cancelled before commit). Basically it ensures the subscribes is done in an effect.

It also removes the async/batching done in unstated.

Breaking changes:
- `setState` is now sync